### PR TITLE
fix: Key Remapの削除・無効化ができない問題を修正 (#17)

### DIFF
--- a/cmd-eikana/Base.lproj/Main.storyboard
+++ b/cmd-eikana/Base.lproj/Main.storyboard
@@ -759,7 +759,7 @@
                                                     </prototypeCellViews>
                                                 </tableColumn>
                                                 <tableColumn identifier="input" width="150" minWidth="150" maxWidth="150" id="4Lt-aZ-uP6">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="input">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="input">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -793,7 +793,7 @@
                                                     </prototypeCellViews>
                                                 </tableColumn>
                                                 <tableColumn identifier="output" width="150" minWidth="150" maxWidth="150" id="enk-hD-eRH">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="output">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="output">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -830,7 +830,7 @@
                                                     </prototypeCellViews>
                                                 </tableColumn>
                                                 <tableColumn identifier="mapping-menu" width="71" minWidth="71" maxWidth="71" id="6aP-Xx-X5J">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="menu">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="menu">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -848,12 +848,12 @@
                                                                 <popUpButton identifier="hage" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dzf-C4-fIi" customClass="MappingMenu" customModule="_英かな" customModuleProvider="target">
                                                                     <rect key="frame" x="2" y="-2" width="71" height="21"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <popUpButtonCell key="cell" type="bevel" title="menu" bezelStyle="regularSquare" image="popUpButtonCell:H2F-I4-Cda:image" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" identifier="test" inset="2" pullsDown="YES" id="H2F-I4-Cda">
+                                                                    <popUpButtonCell key="cell" type="bevel" title="…" bezelStyle="regularSquare" image="popUpButtonCell:H2F-I4-Cda:image" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" identifier="test" inset="2" pullsDown="YES" id="H2F-I4-Cda">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="menu"/>
                                                                         <menu key="menu" id="BOb-Li-1q3">
                                                                             <items>
-                                                                                <menuItem title="menu" state="on" hidden="YES" id="hM9-HT-fqx"/>
+                                                                                <menuItem title="…" state="on" hidden="YES" id="hM9-HT-fqx"/>
                                                                                 <menuItem title="move to the top" id="SPl-n7-KTj">
                                                                                     <modifierMask key="keyEquivalentModifierMask"/>
                                                                                 </menuItem>

--- a/cmd-eikana/Base.lproj/Main.storyboard
+++ b/cmd-eikana/Base.lproj/Main.storyboard
@@ -848,7 +848,7 @@
                                                                 <popUpButton identifier="hage" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dzf-C4-fIi" customClass="MappingMenu" customModule="_英かな" customModuleProvider="target">
                                                                     <rect key="frame" x="2" y="-2" width="71" height="21"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <popUpButtonCell key="cell" type="bevel" title="…" bezelStyle="regularSquare" image="popUpButtonCell:H2F-I4-Cda:image" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" identifier="test" inset="2" pullsDown="YES" id="H2F-I4-Cda">
+                                                                    <popUpButtonCell key="cell" type="bevel" title="…" bezelStyle="regularSquare" imagePosition="left" alignment="center" lineBreakMode="truncatingTail" state="on" identifier="test" inset="2" arrowPosition="noArrow" pullsDown="YES" id="H2F-I4-Cda">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="menu"/>
                                                                         <menu key="menu" id="BOb-Li-1q3">

--- a/cmd-eikana/Base.lproj/Main.storyboard
+++ b/cmd-eikana/Base.lproj/Main.storyboard
@@ -730,7 +730,7 @@
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="20" minWidth="10" maxWidth="3.4028234663852886e+38" id="5Q2-ZP-bZo">
+                                                <tableColumn identifier="enable" width="20" minWidth="10" maxWidth="3.4028234663852886e+38" id="5Q2-ZP-bZo">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -749,7 +749,7 @@
                                                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="auW-1h-yOd">
                                                                     <rect key="frame" x="-1" y="0.0" width="22" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" enabled="NO" state="on" inset="2" id="t7J-gl-EMm">
+                                                                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" state="on" inset="2" id="t7J-gl-EMm">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                         <font key="font" metaFont="system"/>
                                                                     </buttonCell>

--- a/cmd-eikana/Base.lproj/Main.storyboard
+++ b/cmd-eikana/Base.lproj/Main.storyboard
@@ -723,14 +723,14 @@
                                     <rect key="frame" x="1" y="1" width="408" height="201"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="gjn-0M-XP2" viewBased="YES" id="wr4-vJ-30a">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" alternatingRowBackgroundColors="YES" columnSelection="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="gjn-0M-XP2" viewBased="YES" id="wr4-vJ-30a">
                                             <rect key="frame" x="0.0" y="0.0" width="408" height="178"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="enable" width="20" minWidth="10" maxWidth="3.4028234663852886e+38" id="5Q2-ZP-bZo">
+                                                <tableColumn identifier="enable" width="20" minWidth="20" maxWidth="20" id="5Q2-ZP-bZo">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -740,7 +740,7 @@
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="NO" userResizable="NO"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="3mX-PW-YrB">
                                                             <rect key="frame" x="1" y="1" width="25" height="17"/>
@@ -758,7 +758,7 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
-                                                <tableColumn identifier="input" width="150" minWidth="40" maxWidth="1000" id="4Lt-aZ-uP6">
+                                                <tableColumn identifier="input" width="150" minWidth="150" maxWidth="150" id="4Lt-aZ-uP6">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="input">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -768,7 +768,7 @@
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="NO" userResizable="NO"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="A9o-Ia-mvS">
                                                             <rect key="frame" x="29" y="1" width="150" height="17"/>
@@ -792,7 +792,7 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
-                                                <tableColumn identifier="output" width="150" minWidth="40" maxWidth="1000" id="enk-hD-eRH">
+                                                <tableColumn identifier="output" width="150" minWidth="150" maxWidth="150" id="enk-hD-eRH">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="output">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -802,7 +802,7 @@
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="NO" userResizable="NO"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="3AJ-I4-GtP">
                                                             <rect key="frame" x="182" y="1" width="150" height="17"/>
@@ -829,17 +829,17 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
-                                                <tableColumn identifier="mapping-menu" width="67" minWidth="10" maxWidth="3.4028234663852886e+38" id="6aP-Xx-X5J">
-                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <tableColumn identifier="mapping-menu" width="71" minWidth="71" maxWidth="71" id="6aP-Xx-X5J">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="menu">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
                                                     <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="HyT-az-VxL">
                                                         <font key="font" metaFont="system"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="NO" userResizable="NO"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="l6F-KR-70l">
                                                             <rect key="frame" x="335" y="1" width="71" height="17"/>

--- a/cmd-eikana/Info.plist
+++ b/cmd-eikana/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.1</string>
+	<string>2.4.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/cmd-eikana/ShortcutsController.swift
+++ b/cmd-eikana/ShortcutsController.swift
@@ -19,7 +19,7 @@ func saveKeyMappings() {
 func keyMappingListToShortcutList() {
   shortcutList = [:]
 
-  for val in keyMappingList {
+  for val in keyMappingList where val.enable {
     let key = val.input.keyCode
 
     if shortcutList[key] == nil {
@@ -68,11 +68,24 @@ class ShortcutsController: NSViewController, NSTableViewDataSource, NSTableViewD
         button.target = self
         button.action = #selector(ShortcutsController.remove(_:))
       }
+      if id.rawValue == "enable" {
+        let button = cell.subviews[0] as! NSButton
+
+        button.state = keyMappingList[row].enable ? .on : .off
+        button.tag = row
+        button.target = self
+        button.action = #selector(ShortcutsController.toggleEnable(_:))
+      }
 
       return cell
     }
     return nil
   }
+  @objc func toggleEnable(_ sender: NSButton) {
+    keyMappingList[sender.tag].enable.toggle()
+    tableRreload()
+  }
+
   @objc func remove(_ sender: MappingMenu) {
     activeKeyTextField?.blur()
 

--- a/cmd-eikana/ja.lproj/Main.strings
+++ b/cmd-eikana/ja.lproj/Main.strings
@@ -359,8 +359,8 @@
 /* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
 "gVA-U4-sdL.title" = "Paste";
 
-/* Class = "NSMenuItem"; title = "menu"; ObjectID = "hM9-HT-fqx"; */
-"hM9-HT-fqx.title" = "menu";
+/* Class = "NSMenuItem"; title = "…"; ObjectID = "hM9-HT-fqx"; */
+"hM9-HT-fqx.title" = "…";
 
 /* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
 "hQb-2v-fYv.title" = "Smart Quotes";

--- a/cmd-eikanaTests/ShortcutsControllerTests.swift
+++ b/cmd-eikanaTests/ShortcutsControllerTests.swift
@@ -1,0 +1,138 @@
+//
+//  ShortcutsControllerTests.swift
+//  cmd-eikanaTests
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import _英かな
+
+@Suite(.serialized)
+struct ShortcutsControllerTests {
+
+  // MARK: - Helper
+
+  func createShortcut(keyCode: UInt16 = 0, flags: UInt64 = 0) -> KeyboardShortcut {
+    KeyboardShortcut(keyCode: CGKeyCode(keyCode), flags: CGEventFlags(rawValue: flags))
+  }
+
+  func createMapping(inputKeyCode: UInt16, outputKeyCode: UInt16, enable: Bool = true)
+    -> KeyMapping
+  {
+    KeyMapping(
+      input: createShortcut(keyCode: inputKeyCode),
+      output: createShortcut(keyCode: outputKeyCode),
+      enable: enable
+    )
+  }
+
+  // MARK: - keyMappingListToShortcutList Tests
+
+  @Test func enabledMappingsAreAddedToShortcutList() {
+    // Setup
+    let originalList = keyMappingList
+    let originalShortcutList = shortcutList
+    defer {
+      keyMappingList = originalList
+      shortcutList = originalShortcutList
+    }
+
+    keyMappingList = [
+      createMapping(inputKeyCode: 55, outputKeyCode: 102, enable: true)
+    ]
+
+    // Execute
+    keyMappingListToShortcutList()
+
+    // Verify
+    #expect(shortcutList[55] != nil)
+    #expect(shortcutList[55]?.count == 1)
+  }
+
+  @Test func disabledMappingsAreNotAddedToShortcutList() {
+    // Setup
+    let originalList = keyMappingList
+    let originalShortcutList = shortcutList
+    defer {
+      keyMappingList = originalList
+      shortcutList = originalShortcutList
+    }
+
+    keyMappingList = [
+      createMapping(inputKeyCode: 55, outputKeyCode: 102, enable: false)
+    ]
+
+    // Execute
+    keyMappingListToShortcutList()
+
+    // Verify
+    #expect(shortcutList[55] == nil)
+  }
+
+  @Test func mixedEnableMappingsFilteredCorrectly() {
+    // Setup
+    let originalList = keyMappingList
+    let originalShortcutList = shortcutList
+    defer {
+      keyMappingList = originalList
+      shortcutList = originalShortcutList
+    }
+
+    keyMappingList = [
+      createMapping(inputKeyCode: 55, outputKeyCode: 102, enable: true),  // Command_L -> 英数
+      createMapping(inputKeyCode: 54, outputKeyCode: 104, enable: false),  // Command_R -> かな (disabled)
+      createMapping(inputKeyCode: 56, outputKeyCode: 103, enable: true),  // Shift_L -> something
+    ]
+
+    // Execute
+    keyMappingListToShortcutList()
+
+    // Verify
+    #expect(shortcutList[55] != nil)  // enabled
+    #expect(shortcutList[54] == nil)  // disabled
+    #expect(shortcutList[56] != nil)  // enabled
+  }
+
+  @Test func emptyMappingListResultsInEmptyShortcutList() {
+    // Setup
+    let originalList = keyMappingList
+    let originalShortcutList = shortcutList
+    defer {
+      keyMappingList = originalList
+      shortcutList = originalShortcutList
+    }
+
+    keyMappingList = []
+
+    // Execute
+    keyMappingListToShortcutList()
+
+    // Verify
+    #expect(shortcutList.isEmpty)
+  }
+
+  @Test func multipleMappingsWithSameInputKeyCode() {
+    // Setup
+    let originalList = keyMappingList
+    let originalShortcutList = shortcutList
+    defer {
+      keyMappingList = originalList
+      shortcutList = originalShortcutList
+    }
+
+    // 同じキーコードで複数のマッピング（有効なもののみカウント）
+    keyMappingList = [
+      createMapping(inputKeyCode: 55, outputKeyCode: 102, enable: true),
+      createMapping(inputKeyCode: 55, outputKeyCode: 104, enable: true),
+      createMapping(inputKeyCode: 55, outputKeyCode: 103, enable: false),  // disabled
+    ]
+
+    // Execute
+    keyMappingListToShortcutList()
+
+    // Verify
+    #expect(shortcutList[55]?.count == 2)  // 有効な2つのみ
+  }
+}


### PR DESCRIPTION
## Summary
- チェックボックスを有効化し、マッピングのEnable/Disableができるように
- メニューボタンのテキストを「…」に変更
- プルダウン矢印を非表示にしてシンプルに
- テーブルのレイアウトを改善（列幅固定、ヘッダー追加、中央寄せ、列並び替え無効化）
- バージョンを2.4.2に更新

Refs #17

## Test plan
- [x] Key Remapのチェックボックスでマッピングを有効/無効にできることを確認
- [x] 「…」ボタンからメニューが開き、削除や移動ができることを確認
- [x] テーブルのレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)